### PR TITLE
move missing dependency resolution

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,7 +124,7 @@ if(CMAKE_HIP_COMPILER)
         )
         install(RUNTIME_DEPENDENCY_SET rocm
                 DIRECTORIES ${HIP_BIN_INSTALL_DIR} ${HIP_LIB_INSTALL_DIR}
-                PRE_INCLUDE_REGEXES hipblas rocblas amdhip64 rocsolver amd_comgr hsa-runtime64 rocsparse tinfo rocprofiler-register drm drm_amdgpu numa elf
+                PRE_INCLUDE_REGEXES hipblas rocblas amdhip64 rocsolver roctx64 amd_comgr hsa-runtime64 rocsparse tinfo rocprofiler-register drm drm_amdgpu numa elf
                 PRE_EXCLUDE_REGEXES ".*"
                 POST_EXCLUDE_REGEXES "system32"
             RUNTIME DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT HIP

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,7 @@ RUN --mount=type=cache,target=/root/.ccache \
         && cmake --build --parallel ${PARALLEL} --preset 'ROCm 6' \
         && cmake --install build --component HIP --strip --parallel ${PARALLEL}
 RUN rm -f dist/lib/ollama/rocm/rocblas/library/*gfx90[06]*
+RUN find dist/lib/ollama
 
 FROM --platform=linux/arm64 nvcr.io/nvidia/l4t-jetpack:${JETPACK5VERSION} AS jetpack-5
 ARG CMAKEVERSION
@@ -162,7 +163,7 @@ COPY --from=build /bin/ollama /bin/ollama
 
 FROM ubuntu:25.10 AS default
 RUN apt-get update \
-    && apt-get install -y ca-certificates rocminfo libroctx64-4 libvulkan1 \
+    && apt-get install -y ca-certificates rocminfo libvulkan1 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=archive /bin /usr/bin


### PR DESCRIPTION
- instead of adding in the final image, add it as part of the ollama build

THis improves my earlier proposal for missing dependency for rocm 6.4.4 ...add the missing library as output of the ollama rocm build instead of adding it later as a ubuntu package


(THis also opens up the possibility for ROCm 7, expect another PR soonish for that :) ) 